### PR TITLE
修复错误拼接的 API 地址

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ async function main () {
 
 // 调用IOTQQ WebAPI
 async function callApi (name, params) {
-  const url = `${WEB_API}/LuaApiCaller?qq=${LOGIN_QQ}&funcname=${name}&timeout=10`
+  const url = `${WEB_API.replace(/\/+$/, '')}/LuaApiCaller?qq=${LOGIN_QQ}&funcname=${name}&timeout=10`
   if (params) return rp.post(url, { body: params })
   return rp.get(url)
 }


### PR DESCRIPTION
修复由于拼接的 API 地址末尾有多个的斜杠，而导致服务器响应500错误问题

假如配置文件中设置的 WEB_API 值为：`http://127.0.0.1:8888/v1/`

拼接的字符串就会是 `http://127.0.0.1:8888/v1//LuaApiCaller?qq=1111&funcname=SendMsg&timeout=10`

发生请求错误，如图：

![](https://user-images.githubusercontent.com/22412567/74865416-0bfedb80-538c-11ea-92a7-60d84d8bb4c0.png)

![](https://user-images.githubusercontent.com/22412567/74865503-2b960400-538c-11ea-8d46-15a2c8474c3c.png)

所以，WEB_API 值末尾去除多余斜杠

```js
WEB_API.replace(/\/+$/, '')
```